### PR TITLE
fix: get rid of typescript errors and svelte warnings.

### DIFF
--- a/src/routes/sveet/[id]/Cell.svelte
+++ b/src/routes/sveet/[id]/Cell.svelte
@@ -1,3 +1,5 @@
+<!-- svelte-ignore a11y-autofocus -->
+
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 	import type { SveetCell } from './sveet';


### PR DESCRIPTION
Eleminates 6 errors, 1 warning, and 1 hint

```
# npm run check

> shesvet@0.0.1 check
> svelte-kit sync && svelte-check --tsconfig ./tsconfig.json


====================================
Loading svelte-check in workspace: .../sveet
Getting Svelte diagnostics...

.../sveet/src/routes/sveet/[id]/sveet.ts:102:12
Hint: 'key' is declared but its value is never read. 
    },
    has(_, key) {
      return true;


.../sveet/src/routes/sveet/[id]/sveet.ts:85:7
Error: Parameter 'a' implicitly has an 'any' type. 
const formulaFunctions = {
  sum(a, b) {
    return a + b


.../sveet/src/routes/sveet/[id]/sveet.ts:85:10
Error: Parameter 'b' implicitly has an 'any' type. 
const formulaFunctions = {
  sum(a, b) {
    return a + b


.../sveet/src/routes/sveet/[id]/sveet.ts:94:52
Error: Element implicitly has an 'any' type because expression of type 'string | symbol' can't be used to index type '{ sum(a: any, b: any): any; }'.
  No index signature with a parameter of type 'string' was found on type '{ sum(a: any, b: any): any; }'. 
      if (propertyName === Symbol.unscopables) return [];
      if (propertyName in formulaFunctions) return formulaFunctions[propertyName];



.../sveet/src/routes/sveet/[id]/sveet.ts:96:28
Error: Object is possibly 'undefined'. 

      const displayValue = sveet.get(propertyName as string).displayValue;
      if (detecting) {


.../sveet/src/routes/sveet/[id]/sveet.ts:111:7
Error: Variable 'storesToSubscribe' implicitly has type 'any[]' in some locations where its type cannot be determined. 
  const fn = new Function('sveet', `with(sveet) { ${formulaValue.replace('=', 'return ')} }`);
  let storesToSubscribe = [];
  let detecting = true;


.../sveet/src/routes/sveet/[id]/sveet.ts:115:32
Error: Variable 'storesToSubscribe' implicitly has an 'any[]' type. 
  detecting = false;
  const derivedStore = derived(storesToSubscribe, () => {
    return fn(obj);


.../sveet/src/routes/sveet/[id]/Cell.svelte:44:4
Warn: A11y: Avoid using autofocus (svelte)
        {:else if mode === Mode.Editing}<input
                        autofocus
                        bind:value={$editValue}


====================================
svelte-check found 6 errors, 1 warning, and 1 hint
```