### PR TITLE
fix: keep focus in editing state

### DIFF
--- a/src/routes/sveet/[id]/Cell.svelte
+++ b/src/routes/sveet/[id]/Cell.svelte
@@ -44,7 +44,7 @@
 			autofocus
 			bind:value={$editValue}
 			on:blur={() => finishEditing(true)}
-			on:keydown={(event) => {
+			on:keydown|stopPropagation={(event) => {
 				switch(event.key) {
 					case 'Enter':
 						finishEditing(true);


### PR DESCRIPTION
Stop propagation on `keydown` event to enable keyboard navigation (arrow-keys, home, end) within the input element.